### PR TITLE
Add missing dependency

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,4 +23,5 @@ mkdir -p $DEACTIVATE_DIR
 
 cp $RECIPE_DIR/scripts/activate.sh $ACTIVATE_DIR/pyferret-activate.sh
 cp $RECIPE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/pyferret-deactivate.sh
-cp $RECIPE_DIR/scripts/pyferret $PREFIX/bin
+cp $RECIPE_DIR/scripts/pyferret $PREFIX/bin/pyferret
+ln -s $PREFIX/bin/pyferret $PREFIX/bin/ferret

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
         - site_specific.patch
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win or py3k or osx]
 
 requirements:
@@ -29,6 +29,7 @@ requirements:
         - numpy x.x
         - cairo
         - pango
+        - pyqt
         - libgcc
 
 test:


### PR DESCRIPTION
Added missing `pyqt` dependency and a `symlink` for `pyferret` &rarr; `ferret`.
