### PR TITLE
Qt5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - osx-platform_specific.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or py3k]
 
 requirements:
@@ -33,7 +33,7 @@ requirements:
     - cairo 1.14.*
     - pango 1.40.*
     - pixman 0.34.*
-    - pyqt 4.11.*
+    - pyqt 5.6.*
     - libgcc  # [linux]
     - libgfortran  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ requirements:
     - cairo 1.14.*
     - pango 1.40.*
     - pixman 0.34.*
-    - pyqt 5.6.*
+    - pyqt 5.6.*  # [not osx]
+    - pyqt 4.11.*  # [osx]
     - libgcc  # [linux]
     - libgfortran  # [osx]
 

--- a/recipe/site_specific.patch
+++ b/recipe/site_specific.patch
@@ -6,7 +6,7 @@ diff -Naur PyFerret-7.1.0-final.orig/external_functions/ef_utility/site_specific
  ## Python version used by PyFerret
  ## =========================
 -PYTHON_EXE = python2.6
-+PYTHON_EXE = python$(PY_VER)
++PYTHON_EXE = $PYTHON
  # PYTHON_EXE = python2.7
  # PYTHON_EXE = python3.6
  


### PR DESCRIPTION
`OS X` will likely fail because `conda-forge` does not provide `Qt 5` for Mac.