### PR TITLE
Define and use FER_DIR (not FER_LIBS); remove dependency version restrictions

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -1,8 +1,24 @@
+cairo:
+- '1.14'
+netcdf_fortran:
+- '4.4'
 numpy:
 - '1.9'
+pango:
+- '1.40'
 pin_run_as_build:
-  python:
+  cairo:
     max_pin: x.x
+  netcdf-fortran:
+    max_pin: x.x
+  pango:
+    max_pin: x.x
+  pixman:
+    max_pin: x.x
+  python:
     min_pin: x.x
+    max_pin: x.x
+pixman:
+- '0.34'
 python:
 - '2.7'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -1,14 +1,30 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+cairo:
+- '1.14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+netcdf_fortran:
+- '4.4'
 numpy:
 - '1.9'
+pango:
+- '1.40'
 pin_run_as_build:
-  python:
+  cairo:
     max_pin: x.x
+  netcdf-fortran:
+    max_pin: x.x
+  pango:
+    max_pin: x.x
+  pixman:
+    max_pin: x.x
+  python:
     min_pin: x.x
+    max_pin: x.x
+pixman:
+- '0.34'
 python:
 - '2.7'

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (`@conda-forge-admin, please rerender`)
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,27 +10,26 @@ source:
   sha256: de5359f77e19d4b82e84b35b0092cdeab3eadf3166301187979c8cec45d4e55c
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or py3k]
 
 requirements:
   build:
     - python
     - numpy
-    - netcdf-fortran 4.4.*
-    - cairo 1.14.*
-    - pango 1.40.*
-    - pixman 0.34.*
+    - netcdf-fortran
+    - cairo
+    - pango
+    - pixman
     - gcc  # [not win]
   run:
     - python
     - numpy
-    - netcdf-fortran 4.4.*
-    - cairo 1.14.*
-    - pango 1.40.*
-    - pixman 0.34.*
-    - pyqt 5.6.*  # [not osx]
-    - pyqt 4.11.*  # [osx]
+    - netcdf-fortran
+    - cairo
+    - pango
+    - pixman
+    - pyqt
     - libgcc  # [linux]
     - libgfortran  # [osx]
 

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -2,6 +2,8 @@
 
 export _CONDA_SET_FERRET=1
 
+export FER_DIR="$CONDA_PREFIX"
+
 ## Dataset directory (not packaged yet).
 export FER_DSETS="$CONDA_PREFIX/share/fer_dsets"
 

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 if [[ -n "$_CONDA_SET_FERRET" ]]; then
+  unset FER_DIR
+  unset FER_DSETS
   unset FER_DATA
   unset FER_DESCR
-  unset FER_DSETS
-  unset FER_FONTS
-  unset FER_GO
   unset FER_GRIDS
-  unset FER_LIBS
+  unset FER_GO
   unset FER_PALETTE
+  unset FER_FONTS
   unset PYFER_EXTERNAL_FUNCTIONS
   unset -f Faddpath
 fi

--- a/recipe/scripts/pyferret
+++ b/recipe/scripts/pyferret
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "${FER_LIBS}" ]; then
+if [ -z "${FER_DIR}" ]; then
     echo "**ERROR: Ferret environment variables are not defined"
     exit 1
 fi


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (`@conda-forge-admin, please rerender`)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Revised pyferret script to check FER_DIR as FER_LIBS no longer defined or used.
Defined/undefined FER_DIR in activate/deactivate.
Remove dependency version restrictions, particularly qt/pyqt on osx as PyQt5 is available and can be used.
