### PR TITLE
Update to PyFerret v7.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.4.3" %}
+{% set version = "7.5.0" %}
 
 package:
   name: pyferret
@@ -7,7 +7,7 @@ package:
 source:
   fn: pyferret-{{ version }}.tar.gz
   url: https://github.com/NOAA-PMEL/PyFerret/archive/{{ version }}.tar.gz
-  sha256: 27442cc6baceb0a0b3c583c1622cd6f62a96c3fc8666a882c60d2c80f932ffbf
+  sha256: 5e18051e6e68374445a3bdd08fff278f50f03d94f32d6f7960afcd587266216b
   patches:
     - intel-mac.patch  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: pyferret-{{ version }}.tar.gz
-  url: https://github.com/NOAA-PMEL/PyFerret/archive/{{ version }}.tar.gz
+  url: https://github.com/NOAA-PMEL/PyFerret/archive/v{{ version }}.tar.gz
   sha256: 5e18051e6e68374445a3bdd08fff278f50f03d94f32d6f7960afcd587266216b
   patches:
     - intel-mac.patch  # [osx]


### PR DESCRIPTION
Definitions for FC and CC are now part of site_specific.mk;
removed from platform_specific.mk.* files.
By not adding them to the site_specific.mk files used here,
presumably the shell environment variable values will be used.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
