### PR TITLE
Rebuild with latest NetCDF library

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - intel-mac.patch  # [osx]
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win]
 
 requirements:
@@ -22,6 +22,7 @@ requirements:
     - python
     - numpy
     - netcdf-fortran
+    - netcdf
     - cairo
     - pango
     - pixman
@@ -29,6 +30,7 @@ requirements:
     - python
     - numpy
     - netcdf-fortran
+    - netcdf
     - cairo
     - pango
     - pixman


### PR DESCRIPTION
Bump build number to rebuild with latest netcdf library.
Explicitly include netcdf (instead of relying on dependency from netcdf-fortran) to see if this helps with NetCDF updates

<code>@<space/>conda-forge-admin, please rerender</code>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
